### PR TITLE
Add space only when git branch name available

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -420,11 +420,12 @@ if is-at-least 4.3.7 ; then
         if [[ -n $vcs_info_msg_0_ ]] ; then # we're in a repository
             if [[ $vcs_info_msg_0_ = git ]] ; then
                 revname=$(git name-rev --always --name-only HEAD 2>/dev/null)
+                if [ "$revname" ] ; then revname="$revname " fi
                 is-at-least 4.3.10 || vcs_info_msg_1_=$(git rev-list --max-count 1 HEAD) # older zsh missed this feature
                 rev=$vcs_info_msg_1_[0,7] # 7 chars is enough revhash for anyone
                 [[ -n $vcs_info_msg_3_ ]] && action="$vcs_info_msg_3_ " || action=""
             fi
-            psvar[1]=("$revname ")
+            psvar[1]=("$revname")
             psvar[2]=("$action")
         else
             psvar[1]=("")


### PR DESCRIPTION
This PR removes extra whitespace entering the prompt when outside the context of a git repository.

Before:
![image](https://user-images.githubusercontent.com/1300032/26862218-d01a60f8-4b8c-11e7-87d8-f1d29e10166c.png)

After:
![image](https://user-images.githubusercontent.com/1300032/26862243-f94e9778-4b8c-11e7-8307-73fb95ffa05d.png)